### PR TITLE
Support Elm 0.16

### DIFF
--- a/Mario.elm
+++ b/Mario.elm
@@ -47,33 +47,36 @@ update (dt, keys) mario =
 jump : Keys -> Model -> Model
 jump keys mario =
     if keys.y > 0 && mario.vy == 0
-      then { mario | vy <- 6.0 }
+      then { mario | vy = 6.0 }
       else mario
 
 
 gravity : Float -> Model -> Model
 gravity dt mario =
     { mario |
-        vy <- if mario.y > 0 then mario.vy - dt/4 else 0
+        vy = if mario.y > 0 then mario.vy - dt/4 else 0
     }
 
 
 physics : Float -> Model -> Model
 physics dt mario =
     { mario |
-        x <- mario.x + dt * mario.vx,
-        y <- max 0 (mario.y + dt * mario.vy)
+        x = mario.x + dt * mario.vx,
+        y = max 0 (mario.y + dt * mario.vy)
     }
 
 
 walk : Keys -> Model -> Model
 walk keys mario =
     { mario |
-        vx <- toFloat keys.x,
-        dir <-
-          if  | keys.x < 0 -> Left
-              | keys.x > 0 -> Right
-              | otherwise  -> mario.dir
+        vx = toFloat keys.x,
+        dir =
+          if keys.x < 0 then
+            Left
+          else if keys.x > 0 then
+            Right
+          else
+            mario.dir
     }
 
 
@@ -84,9 +87,12 @@ view (w',h') mario =
   let (w,h) = (toFloat w', toFloat h')
 
       verb =
-        if  | mario.y  >  0 -> "jump"
-            | mario.vx /= 0 -> "walk"
-            | otherwise     -> "stand"
+        if  mario.y > 0 then
+          "jump"
+        else if mario.vx /= 0 then
+          "walk"
+        else
+          "stand"
 
       dir =
         case mario.dir of

--- a/elm-package.json
+++ b/elm-package.json
@@ -8,8 +8,8 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 3.0.0",
-        "evancz/elm-html": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "3.0.0 <= v < 4.0.0",
+        "evancz/elm-html": "4.0.2 <= v < 5.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
Updated the dependencies and follow the new syntax.
According to https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.16.md